### PR TITLE
read partial content if read will overrun

### DIFF
--- a/httpio_suite_test.go
+++ b/httpio_suite_test.go
@@ -1,12 +1,12 @@
 package httpio
 
 import (
-    "net/http"
-    "net/url"
-    "testing"
+	"net/http"
+	"net/url"
+	"testing"
 
-    . "github.com/onsi/ginkgo"
-    . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestHttpio(t *testing.T) {
@@ -14,53 +14,52 @@ func TestHttpio(t *testing.T) {
 	RunSpecs(t, "Httpio Suite")
 }
 
-
 type handler struct {
-    url    *url.URL
-    header http.Header
-    method string
+	url    *url.URL
+	header http.Header
+	method string
 
-    responseCode    int
-    responseBody    []byte
-    responseHeaders map[string][]string
+	responseCode    int
+	responseBody    []byte
+	responseHeaders map[string][]string
 }
 
 func newMockHandler() *handler {
-    return &handler{responseHeaders: make(map[string][]string)}
+	return &handler{responseHeaders: make(map[string][]string)}
 }
 
 func (h *handler) expect(method string, expectUrl *url.URL, header http.Header) {
-    h.url = expectUrl
-    h.header = header
-    h.method = method
+	h.url = expectUrl
+	h.header = header
+	h.method = method
 }
 
 func (h *handler) response(statusCode int, body []byte, headers map[string][]string) {
-    for k, v := range headers {
-        h.responseHeaders[k] = v
-    }
+	for k, v := range headers {
+		h.responseHeaders[k] = v
+	}
 
-    h.responseBody = body
-    h.responseCode = statusCode
+	h.responseBody = body
+	h.responseCode = statusCode
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-    Expect(req.Method).To(Equal(h.method))
-    Expect(req.URL.String()).To(Equal(h.url.Path))
+	Expect(req.Method).To(Equal(h.method))
+	Expect(req.URL.String()).To(Equal(h.url.Path))
 
-    // Don't care about the UA header.
-    req.Header.Del("User-Agent")
-    Expect(req.Header).To(Equal(h.header))
+	// Don't care about the UA header.
+	req.Header.Del("User-Agent")
+	Expect(req.Header).To(Equal(h.header))
 
-    for k, v := range h.responseHeaders {
-        for _, s := range v {
-            w.Header().Set(k, s)
-        }
-    }
+	for k, v := range h.responseHeaders {
+		for _, s := range v {
+			w.Header().Set(k, s)
+		}
+	}
 
-    if h.responseCode != 0 {
-        w.WriteHeader(h.responseCode)
-    }
+	if h.responseCode != 0 {
+		w.WriteHeader(h.responseCode)
+	}
 
-    w.Write(h.responseBody)
+	w.Write(h.responseBody)
 }

--- a/io.go
+++ b/io.go
@@ -199,9 +199,6 @@ func (r *ReadAtCloser) Etag() string {
 // ReadAt satisfies the io.ReaderAt interface. It requires the ReadAtCloser be previously configured.
 func (r *ReadAtCloser) ReadAt(b []byte, start int64) (n int, err error) {
 	end := start + int64(len(b))
-	if r.contentLength < end {
-		return 0, ErrReadFromSource
-	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
@@ -226,6 +223,10 @@ func (r *ReadAtCloser) ReadAt(b []byte, start int64) (n int, err error) {
 	bt, err = ioutil.ReadAll(res.Body)
 
 	copy(b, bt)
+
+	if r.contentLength < end {
+		return int(res.ContentLength - start), io.ErrUnexpectedEOF
+	}
 
 	l := int64(len(b))
 	if l > res.ContentLength {

--- a/io_test.go
+++ b/io_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -35,7 +36,7 @@ var _ = Describe("io", func() {
 			server.AppendHandlers(ghttp.CombineHandlers(mockHandler.ServeHTTP))
 		})
 
-		Context("#headURL", func() {
+		Context(".headURL", func() {
 			var (
 				expectLen int64
 				expectUrl *url.URL
@@ -97,7 +98,7 @@ var _ = Describe("io", func() {
 
 		})
 
-		Context("#WithClient", func() {
+		Context(".WithClient", func() {
 			var (
 				c *http.Client
 				o Option
@@ -133,7 +134,7 @@ var _ = Describe("io", func() {
 			})
 		})
 
-		Context("#WithURL", func() {
+		Context(".WithURL", func() {
 			var (
 				u string
 				o Option
@@ -156,7 +157,7 @@ var _ = Describe("io", func() {
 			})
 		})
 
-		Context("#validateUrl", func() {
+		Context(".validateUrl", func() {
 			var (
 				u   string
 				err error
@@ -204,7 +205,7 @@ var _ = Describe("io", func() {
 			})
 		})
 
-		Context("#hashURL", func() {
+		Context(".hashURL", func() {
 			var (
 				hashScheme uint
 				hashResult hash.Hash
@@ -314,14 +315,16 @@ var _ = Describe("io", func() {
 					readLength := len(fullBody)
 					target = make([]byte, readLength)
 					start = 5
+					mockHandler.expect(http.MethodGet, expectUrl, rangeHead(int(start), int(start)+readLength))
+					mockHandler.response(http.StatusPartialContent, fullBody, nil)
 				})
 
 				It("should return an error", func() {
-					Expect(err).To(MatchError(ErrReadFromSource))
+					Expect(err).To(MatchError(io.ErrUnexpectedEOF))
 				})
 
-				It("should return a zero length", func() {
-					Expect(readLen).To(BeZero())
+				It("should return a length", func() {
+					Expect(readLen).To(Equal(len(fullBody) - int(start)))
 				})
 			})
 


### PR DESCRIPTION
This fixes the expectation that a read could succeed partially. Bytes read will be set and the length of what was read along with an unexpected EOF error are returned.

Oh, and `gofmt`.