### PR TITLE
support hashing in chunks

### DIFF
--- a/httpio_suite_test.go
+++ b/httpio_suite_test.go
@@ -45,8 +45,8 @@ func (h *httpMock) finish() {
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
 	if len(h.expected) > 0 {
-	    Fail("unmatched expectations")
-    }
+		Fail("unmatched expectations")
+	}
 	h.expected = []*request{}
 }
 

--- a/httpio_suite_test.go
+++ b/httpio_suite_test.go
@@ -44,6 +44,9 @@ func newHTTPMock(s *ghttp.Server) *httpMock {
 func (h *httpMock) finish() {
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
+	if len(h.expected) > 0 {
+	    Fail("unmatched expectations")
+    }
 	h.expected = []*request{}
 }
 

--- a/httpio_suite_test.go
+++ b/httpio_suite_test.go
@@ -3,10 +3,13 @@ package httpio
 import (
 	"net/http"
 	"net/url"
+	"reflect"
+	"sync"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 )
 
 func TestHttpio(t *testing.T) {
@@ -14,7 +17,13 @@ func TestHttpio(t *testing.T) {
 	RunSpecs(t, "Httpio Suite")
 }
 
-type handler struct {
+type httpMock struct {
+	mutex    *sync.Mutex
+	expected []*request
+	server   *ghttp.Server
+}
+
+type request struct {
 	url    *url.URL
 	header http.Header
 	method string
@@ -24,42 +33,85 @@ type handler struct {
 	responseHeaders map[string][]string
 }
 
-func newMockHandler() *handler {
-	return &handler{responseHeaders: make(map[string][]string)}
+func newHTTPMock(s *ghttp.Server) *httpMock {
+	return &httpMock{
+		mutex:    new(sync.Mutex),
+		expected: []*request{},
+		server:   s,
+	}
 }
 
-func (h *handler) expect(method string, expectUrl *url.URL, header http.Header) {
-	h.url = expectUrl
-	h.header = header
-	h.method = method
+func (h *httpMock) finish() {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	h.expected = []*request{}
 }
 
-func (h *handler) response(statusCode int, body []byte, headers map[string][]string) {
+func (h *httpMock) expect(method string, expectUrl *url.URL, header http.Header) *httpMock {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	h.expected = append(h.expected, &request{
+		url:             expectUrl,
+		method:          method,
+		header:          header,
+		responseHeaders: make(map[string][]string),
+	})
+	return h
+}
+
+func (h *httpMock) response(statusCode int, body []byte, headers map[string][]string) *httpMock {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	req := h.expected[len(h.expected)-1]
+
 	for k, v := range headers {
-		h.responseHeaders[k] = v
+		req.responseHeaders[k] = v
 	}
 
-	h.responseBody = body
-	h.responseCode = statusCode
+	req.responseBody = body
+	req.responseCode = statusCode
+
+	h.server.AppendHandlers(h.ServeHTTP)
+	return h
 }
 
-func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	Expect(req.Method).To(Equal(h.method))
-	Expect(req.URL.String()).To(Equal(h.url.Path))
+func (h *httpMock) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
 
-	// Don't care about the UA header.
+	if len(h.expected) == 0 {
+		Fail("no expected requests")
+	}
+
+	// We don't care about the UA
 	req.Header.Del("User-Agent")
-	Expect(req.Header).To(Equal(h.header))
+	var (
+		matched bool
+		idx     int
+	)
+	for i, r := range h.expected {
+		if req.Method == r.method && req.URL.String() == r.url.Path && reflect.DeepEqual(req.Header, r.header) {
+			for k, v := range r.responseHeaders {
+				for _, s := range v {
+					w.Header().Set(k, s)
+				}
+			}
 
-	for k, v := range h.responseHeaders {
-		for _, s := range v {
-			w.Header().Set(k, s)
+			if r.responseCode != 0 {
+				w.WriteHeader(r.responseCode)
+			}
+
+			w.Write(r.responseBody)
+			matched = true
+			idx = i
+			break
 		}
 	}
 
-	if h.responseCode != 0 {
-		w.WriteHeader(h.responseCode)
+	if matched {
+		h.expected = append(h.expected[:idx], h.expected[idx+1:]...)
+		return
 	}
-
-	w.Write(h.responseBody)
+	Fail("request did not match any expected request")
 }

--- a/io.go
+++ b/io.go
@@ -186,6 +186,7 @@ func (o *Options) hashURL(hashSize uint) (hash.Hash, error) {
 }
 
 // HashURL takes the hash scheme as a uint (either sha256.Size or md5.Size) and the chunk size, to chunk the hashing into, and returns the hashed URL body in the supplied scheme as a slice of hash.Hash.
+// When the chunk size is < the content length the URL will be read, in parallel, to create the `hash.Hash` for each part of the file of `chunk` size.
 // Setting the chunk size to 0 is translated to "do not chunk" and will hash the content as one.
 func (r *ReadAtCloser) HashURL(scheme uint, chunk int64) ([]hash.Hash, error) {
 	if chunk <= 0 {

--- a/io_test.go
+++ b/io_test.go
@@ -36,6 +36,10 @@ var _ = Describe("io", func() {
 			mockHTTP = newHTTPMock(server)
 		})
 
+		AfterEach(func() {
+			mockHTTP.finish()
+		})
+
 		Context(".headURL", func() {
 			var (
 				expectLen int64
@@ -261,6 +265,10 @@ var _ = Describe("io", func() {
 				client: &http.Client{},
 			}
 			readAtCloser = &ReadAtCloser{options: options}
+		})
+
+		AfterEach(func() {
+			mockHTTP.finish()
 		})
 
 		Context(".Close", func() {

--- a/io_test.go
+++ b/io_test.go
@@ -2,6 +2,7 @@ package httpio
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"hash"
 	"io"
@@ -15,8 +16,8 @@ import (
 
 var _ = Describe("io", func() {
 	var (
-		server      *ghttp.Server
-		mockHandler *handler
+		server   *ghttp.Server
+		mockHTTP *httpMock
 	)
 
 	AfterSuite(func() {
@@ -32,8 +33,7 @@ var _ = Describe("io", func() {
 
 		BeforeEach(func() {
 			server = ghttp.NewServer()
-			mockHandler = newMockHandler()
-			server.AppendHandlers(ghttp.CombineHandlers(mockHandler.ServeHTTP))
+			mockHTTP = newHTTPMock(server)
 		})
 
 		Context(".headURL", func() {
@@ -57,8 +57,9 @@ var _ = Describe("io", func() {
 			Context("when the server does not support range reads", func() {
 				BeforeEach(func() {
 					options.url = expectUrl.String()
-					mockHandler.expect(http.MethodHead, expectUrl, http.Header{})
-					mockHandler.response(http.StatusBadRequest, nil, nil)
+					mockHTTP.expect(http.MethodHead, expectUrl, http.Header{}).
+						response(http.StatusBadRequest, nil, nil)
+
 				})
 
 				It("should return the error", func() {
@@ -79,12 +80,12 @@ var _ = Describe("io", func() {
 					expectLen = 42
 					expectLenString := fmt.Sprintf("%d", expectLen)
 					options.url = expectUrl.String()
-					mockHandler.expect(http.MethodHead, expectUrl, http.Header{})
+					mockHTTP.expect(http.MethodHead, expectUrl, http.Header{})
 					h := map[string][]string{
 						"accept-ranges":  {"bytes"},
 						"content-length": {expectLenString},
 					}
-					mockHandler.response(http.StatusBadRequest, nil, h)
+					mockHTTP.response(http.StatusBadRequest, nil, h)
 				})
 
 				It("should not error", func() {
@@ -230,8 +231,8 @@ var _ = Describe("io", func() {
 				var expectErr string
 
 				BeforeEach(func() {
-					mockHandler.expect(http.MethodGet, expectUrl, http.Header{"Accept-Encoding": []string{"gzip"}})
-					mockHandler.response(http.StatusBadRequest, nil, nil)
+					mockHTTP.expect(http.MethodGet, expectUrl, http.Header{"Accept-Encoding": []string{"gzip"}})
+					mockHTTP.response(http.StatusBadRequest, nil, nil)
 					expectErr = fmt.Sprintf("Error requesting %s, received code: 400 Bad Request", expectUrl.String())
 				})
 
@@ -253,9 +254,8 @@ var _ = Describe("io", func() {
 		)
 
 		BeforeEach(func() {
-			mockHandler = newMockHandler()
 			server = ghttp.NewServer()
-			server.AppendHandlers(ghttp.CombineHandlers(mockHandler.ServeHTTP))
+			mockHTTP = newHTTPMock(server)
 
 			options = &Options{
 				client: &http.Client{},
@@ -315,8 +315,8 @@ var _ = Describe("io", func() {
 					readLength := len(fullBody)
 					target = make([]byte, readLength)
 					start = 5
-					mockHandler.expect(http.MethodGet, expectUrl, rangeHead(int(start), int(start)+readLength))
-					mockHandler.response(http.StatusPartialContent, fullBody, nil)
+					mockHTTP.expect(http.MethodGet, expectUrl, rangeHead(int(start), int(start)+readLength))
+					mockHTTP.response(http.StatusPartialContent, fullBody, nil)
 				})
 
 				It("should return an error", func() {
@@ -334,8 +334,8 @@ var _ = Describe("io", func() {
 				BeforeEach(func() {
 					start = 0
 					target = make([]byte, readSize)
-					mockHandler.expect(http.MethodGet, expectUrl, rangeHead(int(start), readSize))
-					mockHandler.response(http.StatusBadRequest, nil, nil)
+					mockHTTP.expect(http.MethodGet, expectUrl, rangeHead(int(start), readSize))
+					mockHTTP.response(http.StatusBadRequest, nil, nil)
 				})
 
 				It("should return an error", func() {
@@ -353,8 +353,8 @@ var _ = Describe("io", func() {
 				BeforeEach(func() {
 					start = 5
 					target = make([]byte, readSize)
-					mockHandler.expect(http.MethodGet, expectUrl, rangeHead(int(start), int(start)+readSize))
-					mockHandler.response(http.StatusPartialContent, fullBody[start:start+int64(readSize)], nil)
+					mockHTTP.expect(http.MethodGet, expectUrl, rangeHead(int(start), int(start)+readSize))
+					mockHTTP.response(http.StatusPartialContent, fullBody[start:start+int64(readSize)], nil)
 				})
 
 				It("should return an error", func() {
@@ -363,6 +363,115 @@ var _ = Describe("io", func() {
 
 				It("should return a zero length", func() {
 					Expect(readLen).To(Equal(readSize))
+				})
+			})
+		})
+
+		Context(".HashURL", func() {
+			var (
+				expectUrl  *url.URL
+				hashSchema uint
+				chunkSize  int64
+				fullBody   []byte
+
+				err    error
+				hashes []hash.Hash
+			)
+
+			JustBeforeEach(func() {
+				hashes, err = readAtCloser.HashURL(hashSchema, chunkSize)
+			})
+
+			BeforeEach(func() {
+				expectUrl, _ = url.Parse(server.URL() + "/foo")
+				readAtCloser.options.url = expectUrl.String()
+				fullBody = []byte("blahlahbahbl")
+				readAtCloser.contentLength = int64(len(fullBody))
+				hashSchema = sha256.Size
+			})
+
+			Context("with zero chunk size", func() {
+				var expectHash hash.Hash
+
+				BeforeEach(func() {
+					expectHash = sha256.New()
+					expectHash.Write(fullBody)
+					chunkSize = 0
+					mockHTTP.expect(http.MethodGet, expectUrl, rangeHead(0, len(fullBody)))
+					mockHTTP.response(http.StatusPartialContent, fullBody, nil)
+				})
+
+				It("should not error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should return slice of one", func() {
+					Expect(len(hashes)).To(Equal(1))
+				})
+
+				It("should return the expected hash", func() {
+					Expect(hashes[0].Sum(nil)).To(Equal(expectHash.Sum(nil)))
+				})
+			})
+
+			Context("with a chunk size greater than the content", func() {
+				var expectHash hash.Hash
+
+				BeforeEach(func() {
+					expectHash = sha256.New()
+					expectHash.Write(fullBody)
+					chunkSize = int64(len(fullBody) + 1)
+					mockHTTP.expect(http.MethodGet, expectUrl, rangeHead(0, len(fullBody)))
+					mockHTTP.response(http.StatusPartialContent, fullBody, nil)
+				})
+
+				It("should not error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should return slice of one", func() {
+					Expect(len(hashes)).To(Equal(1))
+				})
+
+				It("should return the expected hash", func() {
+					Expect(hashes[0].Sum(nil)).To(Equal(expectHash.Sum(nil)))
+				})
+			})
+
+			Context("with a chunk size less than the content", func() {
+				var (
+					expectHashes []hash.Hash
+				)
+
+				BeforeEach(func() {
+					expectHashes = make([]hash.Hash, 3)
+
+					for i, str := range []string{"blah", "lahb", "ahbl"} {
+						expectHashes[i] = sha256.New()
+						expectHashes[i].Write([]byte(str))
+					}
+
+					chunkSize = int64(4)
+					mockHTTP.expect(http.MethodGet, expectUrl, rangeHead(0, 4)).
+						response(http.StatusPartialContent, fullBody[0:chunkSize], nil).
+						expect(http.MethodGet, expectUrl, rangeHead(4, 8)).
+						response(http.StatusPartialContent, fullBody[chunkSize:chunkSize*2], nil).
+						expect(http.MethodGet, expectUrl, rangeHead(8, 12)).
+						response(http.StatusPartialContent, fullBody[chunkSize*2:chunkSize*3], nil)
+				})
+
+				It("should not error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should return the expected count of hashes", func() {
+					Expect(len(hashes)).To(Equal(3))
+				})
+
+				It("should return the expected hashes", func() {
+					Expect(hashes[0].Sum(nil)).To(Equal(expectHashes[0].Sum(nil)))
+					Expect(hashes[1].Sum(nil)).To(Equal(expectHashes[1].Sum(nil)))
+					Expect(hashes[2].Sum(nil)).To(Equal(expectHashes[2].Sum(nil)))
 				})
 			})
 		})


### PR DESCRIPTION
This updates the `HashURL` method to take a `chunk` size.
When the chunk size is less than the contentLength the URL will be read in multiple parts, in parallel, and a slice of `hash.Hash` interfaces will be returned, the index of each correspond to the chunk number.