### PR TITLE
Defer http response body before doing anything else

### DIFF
--- a/io.go
+++ b/io.go
@@ -277,12 +277,11 @@ func (o *Options) hashURL(hashSize uint) (hash.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode < 200 || res.StatusCode > 399 {
 		return nil, RequestError{StatusCode: res.StatusCode, Url: o.url}
 	}
-
-	defer res.Body.Close()
 
 	switch hashSize {
 	case sha256.Size:


### PR DESCRIPTION
Fix the location of where the defer is setup to close the response body.

Credit to @nbrownjc for finding this.


It may be worth a little time to create an interface from the `http.Client` methods used to mock the client so this, and probably a few other areas, could be tested better. Think on that.