### PR TITLE
Return error when there is/are error(s)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
@@ -57,6 +58,7 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -65,6 +67,7 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/io.go
+++ b/io.go
@@ -308,7 +308,7 @@ func (r *ReadAtCloser) HashURL(scheme uint) ([]hash.Hash, error) {
 	var chunks int64
 
 	// If chunkSize is greater than the content length reset it to the available length and set number of chunks to 1.
-	// Otherwise we need to divide the length by the number of chunks and round up. The final chunkSize will be the sum of the remainder.
+	// Otherwise, we need to divide the length by the number of chunks and round up. The final chunkSize will be the sum of the remainder.
 	if chunkSize > cl {
 		chunkSize = cl
 		chunks = 1
@@ -330,15 +330,21 @@ func (r *ReadAtCloser) HashURL(scheme uint) ([]hash.Hash, error) {
 	wg := sync.WaitGroup{}
 
 	for i := int64(0); i < chunks; i++ {
+		// The remaining size is the smaller of the chunkSize or the chunkSize times the number of chunks already read.
 		remaining := chunkSize
 		if remaining > cl-(i*chunkSize) {
 			remaining = cl - (i * chunkSize)
 		}
 
+		// If remaining ends up less than 0 then the math above to determine the number of chunks is incorrect or something bad happened.
+		if remaining < 0 {
+			return nil, errors.New("failed to properly calculate the hash chunk count")
+		}
+
 		start := chunkSize * i
 
 		wg.Add(1)
-		go func(w *sync.WaitGroup, idx int64, start, size int64, rac *ReadAtCloser) {
+		go func(w *sync.WaitGroup, idx, start, size int64, rac *ReadAtCloser) {
 			defer w.Done()
 			b := make([]byte, size)
 			if _, err := rac.ReadAt(b, start); err != nil {
@@ -369,14 +375,14 @@ func (r *ReadAtCloser) HashURL(scheme uint) ([]hash.Hash, error) {
 func checkErrSlice(es []error) (err error) {
 	for _, e := range es {
 		if e != nil {
-			if err == nil {
+			if err != nil {
 				err = fmt.Errorf("%s: %s", err, e)
 				continue
 			}
 			err = e
 		}
 	}
-	return nil
+	return
 }
 
 // Length returns the reported ContentLength of the URL body.

--- a/io_test.go
+++ b/io_test.go
@@ -3,6 +3,7 @@ package httpio
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -569,6 +570,48 @@ var _ = Describe("io", func() {
 				})
 
 			})
+		})
+	})
+})
+
+var _ = Describe("checkErrSlice", func() {
+	var (
+		es []error
+
+		err error
+	)
+
+	JustBeforeEach(func() {
+		err = checkErrSlice(es)
+	})
+
+	Context("with no errors in slice", func() {
+		BeforeEach(func() {
+			es = make([]error, 0)
+		})
+
+		It("should not return an error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("with one error in slice", func() {
+		BeforeEach(func() {
+			es = []error{nil, errors.New("test error"), nil}
+		})
+
+		It("should return an error", func() {
+			Expect(err).To(MatchError("test error"))
+		})
+	})
+
+	Context("with multiple errors in slice", func() {
+		BeforeEach(func() {
+			es = []error{nil, errors.New("test error 2"), errors.New("test error 1"), nil}
+		})
+
+		It("should return an error", func() {
+			Expect(err).To(MatchError("test error 2: test error 1"))
 		})
 	})
 })


### PR DESCRIPTION
The `checkErrorSlice()` func would always return `nil`.
Guard against the size to hash being a negative number.