### PR TITLE
Allow setting context through an option

### DIFF
--- a/io.go
+++ b/io.go
@@ -72,6 +72,7 @@ const ReadSizeLimit = 32768
 // Options contains the parts to create and use a ReadCloser or ReadAtCloser
 type Options struct {
 	client               *http.Client
+	ctx 				 context.Context
 	hashChunkSize        int64
 	expectHeaders        map[string]string
 	maxConcurrentReaders int64
@@ -175,7 +176,12 @@ func NewReadAtCloser(opts ...Option) (r *ReadAtCloser, err error) {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	useCTX := context.Background()
+	if o.ctx != nil {
+		useCTX = o.ctx
+	}
+
+	ctx, cancel := context.WithCancel(useCTX)
 
 	return &ReadAtCloser{
 		contentLength:     contentLength,
@@ -193,6 +199,13 @@ func NewReadAtCloser(opts ...Option) (r *ReadAtCloser, err error) {
 func WithClient(c *http.Client) Option {
 	return func(o *Options) {
 		o.client = c
+	}
+}
+
+// WithContext allows supplying a context for the ReadAtCloser to use.
+func WithContext(ctx context.Context) Option {
+	return func(o *Options) {
+		o.ctx = ctx
 	}
 }
 

--- a/io.go
+++ b/io.go
@@ -72,7 +72,7 @@ const ReadSizeLimit = 32768
 // Options contains the parts to create and use a ReadCloser or ReadAtCloser
 type Options struct {
 	client               *http.Client
-	ctx 				 context.Context
+	ctx                  context.Context
 	hashChunkSize        int64
 	expectHeaders        map[string]string
 	maxConcurrentReaders int64

--- a/io_test.go
+++ b/io_test.go
@@ -189,6 +189,29 @@ var _ = Describe("io", func() {
 			})
 		})
 
+		Context(".WithContext", func() {
+			var (
+				inCTX context.Context
+				o Option
+			)
+
+			JustBeforeEach(func() {
+				o = WithContext(inCTX)
+				o(testOptions)
+			})
+
+			Context("with a context", func() {
+				BeforeEach(func() {
+					inCTX = context.Background()
+					testOptions = &Options{}
+				})
+
+				It("should set the option context", func() {
+					Expect(testOptions.ctx).To(Equal(inCTX))
+				})
+			})
+		})
+
 		Context(".validateUrl", func() {
 			var (
 				u   string

--- a/io_test.go
+++ b/io_test.go
@@ -192,7 +192,7 @@ var _ = Describe("io", func() {
 		Context(".WithContext", func() {
 			var (
 				inCTX context.Context
-				o Option
+				o     Option
 			)
 
 			JustBeforeEach(func() {


### PR DESCRIPTION
This adds the `WithContext` option to allow the caller to supply a context that we will derive ours from. This will allow the caller to cancel the context passed in to let us know we need to cancel any in-flight operations and exit.
Normally context would be passed in as its own argument, but using an option allows us to add it without creating a breaking change. 
If folks want the more (arguably) idiomatic method of the context being the first func arg we can add that and bump the major version in the future.